### PR TITLE
Add Telethon module compatibility and transformation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ shizu.log
 shizu-tl.session
 shizu-tl.session-journal
 .idea
+venv/

--- a/shizu/inter/inter.py
+++ b/shizu/inter/inter.py
@@ -1,0 +1,36 @@
+import re
+
+
+def transform(code: str) -> str:
+    lines = code.split('\n')
+    transformed_lines = []
+    
+    for line in lines:
+        if re.match(r"^\s*from \.\.inline", line):
+            continue 
+        transformed_lines.append(line)
+    
+    code = '\n'.join(transformed_lines)
+    
+    code = re.sub(r"@loader\.tds", "@loader.module()", code)
+    
+    match = re.search(r"class\s+(\w+)\s*\(\s*loader\.Module\s*\)\s*:", code)
+    if match:
+        module_name = match.group(1)
+        code = re.sub(
+            r"@loader\.module\(\)",
+            f'@loader.module("{module_name}", "telethon", "")',
+            code,
+        )
+    
+    def replace_signature(match):
+        return f"async def {match.group(1)}(self, app, message)"
+    
+    code = re.sub(
+        r"^(\s*)async def (\w+)\(self,\s*message\)",
+        r"\1async def \2(self, app, message)",
+        code,
+        flags=re.MULTILINE,
+    )
+    
+    return code

--- a/shizu/modules/ShizuHelp.py
+++ b/shizu/modules/ShizuHelp.py
@@ -185,11 +185,12 @@ class Help(loader.Module):
                 )
 
                 if commands or inline:
-                    module_emoji = (
-                        self.config["core_modules"]
-                        if module.name in self.cmodules
-                        else self.config["custom_modules"]
-                    )
+                    if hasattr(module, 'm__telethon') and module.m__telethon:
+                        module_emoji = "🪢"
+                    elif module.name in self.cmodules:
+                        module_emoji = self.config["core_modules"]
+                    else:
+                        module_emoji = self.config["custom_modules"]
 
                     text += (
                         f"\n<b>{module_emoji} {module.name}</b> - [ "


### PR DESCRIPTION
## Summary by Sourcery

Add compatibility for Telethon-style modules by transforming them at load time and marking them in the system, and adjust help output to distinguish these modules.

New Features:
- Support loading Telethon-style modules by detecting their syntax and transforming them into compatible modules at runtime.
- Expose a loader.tds decorator alias to maintain compatibility with Telethon module annotations.

Enhancements:
- Tag transformed Telethon modules so they can be visually distinguished in the help output and augment ShizuHelp to show a dedicated emoji for them.